### PR TITLE
Android Studio 2.1.2 Upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.21.7'
     }
 }
 apply plugin: 'com.android.application'
@@ -76,12 +76,12 @@ def generateVersionName = { ->
 
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 24
     buildToolsVersion "22.0.1"
     defaultConfig {
         applicationId "com.eveningoutpost.dexdrip"
         minSdkVersion 17
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 2
         versionName generateVersionName()
         multiDexEnabled true
@@ -111,16 +111,16 @@ dependencies {
     xdripviewerWearApp project(path: ':wear', configuration: 'xdripviewerRelease')
     testCompile 'com.squareup.okhttp:mockwebserver:2.6.0'
     compile 'com.nispok:snackbar:2.10.8'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.squareup.okhttp:okhttp:2.6.0'
-    compile 'com.google.code.gson:gson:2.3'
+    compile 'com.google.code.gson:gson:2.4'
     compile 'com.squareup.retrofit:converter-gson:2.0.0-beta2'
     compile 'com.squareup.retrofit:retrofit:2.0.0-beta2'
     compile 'com.squareup.okhttp:logging-interceptor:2.6.0'
     compile 'com.getpebble:pebblekit:3.0.0'
     compile 'io.reactivex:rxjava:1.0.0'
     compile 'com.github.lecho:hellocharts-android:v1.5.5'
-    compile 'com.google.android.gms:play-services-wearable:7.5.0'
+    compile 'com.google.android.gms:play-services-wearable:9.2.0'
     compile 'com.google.guava:guava:18.0'
     compile 'com.android.support:multidex:1.0.1'
     compile('com.github.nightscout:android-uploader:CORE_FOR_XDRIP') {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
         <meta-data
             android:name="AA_DB_VERSION"
             android:value="41" />
+        <meta-data
+            android:name="AA_MODELS"
+            android:value="com.eveningoutpost.dexdrip.Models.ActiveBgAlert,com.eveningoutpost.dexdrip.Models.ActiveBluetoothDevice,com.eveningoutpost.dexdrip.Models.AlertType,com.eveningoutpost.dexdrip.Models.BgReading,com.eveningoutpost.dexdrip.Models.BgReading,com.eveningoutpost.dexdrip.Models.Calibration,com.eveningoutpost.dexdrip.Models.Calibration,com.eveningoutpost.dexdrip.Models.CalibrationRequest,com.eveningoutpost.dexdrip.Models.Sensor,com.eveningoutpost.dexdrip.Models.TransmitterData,com.eveningoutpost.dexdrip.Models.Treatments,com.eveningoutpost.dexdrip.Models.UserError,com.eveningoutpost.dexdrip.Models.UserNotification,com.eveningoutpost.dexdrip.ShareModels.Models,com.eveningoutpost.dexdrip.UtilityModels.BgSendQueue,com.eveningoutpost.dexdrip.UtilityModels.CalibrationSendQueue,com.eveningoutpost.dexdrip.UtilityModels.SensorSendQueue"/>
 
         <provider
             android:name="com.activeandroid.content.ContentProvider"

--- a/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/xdrip.java
@@ -23,7 +23,11 @@ public class xdrip extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Fabric.with(this, new Crashlytics());
+        if (!BuildConfig.DEBUG) {
+            // Only run Crashlytics when we are not in debug mode.
+            Fabric.with(this, new Crashlytics());
+        }
+
         Context context = getApplicationContext();
         CollectionServiceStarter collectionServiceStarter = new CollectionServiceStarter(context);
         collectionServiceStarter.start(getApplicationContext());

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         apply plugin: 'java'
         apply plugin: 'maven'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 08 12:58:42 EDT 2016
+#Thu Jul 07 01:19:52 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/wear/wear.iml
+++ b/wear/wear.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":wear" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="xDripExp" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":wear" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="xDrip-Experimental" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
@@ -12,10 +12,7 @@
         <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleXdripDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileXdripDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleXdripDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileXdripDebugAndroidTestSources" />
         <afterSyncTasks>
-          <task>generateXdripDebugAndroidTestSources</task>
           <task>generateXdripDebugSources</task>
         </afterSyncTasks>
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
@@ -28,7 +25,7 @@
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/xdrip/debug" />
-    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/androidTest/xdrip/debug" />
+    <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/xdrip/debug" />
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/xdrip/debug" isTestSource="false" generated="true" />
@@ -44,12 +41,21 @@
       <sourceFolder url="file://$MODULE_DIR$/src/xdripDebug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdripDebug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdripDebug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/xdripDebug/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/xdrip/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/xdrip/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/xdrip/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/xdrip/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/xdrip/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/xdrip/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdripDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/assets" type="java-resource" />
@@ -57,6 +63,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/xdrip/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/xdrip/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testXdrip/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/assets" type="java-test-resource" />
@@ -64,6 +79,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTestXdrip/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -71,6 +87,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
@@ -78,6 +103,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
@@ -85,10 +119,12 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/21.0.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/22.0.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-base/7.3.0/jars" />
@@ -96,25 +132,24 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.support/wearable/1.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.ustwo.android/clockwise-wearable/1.0.2/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/xdripRelease" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 23 Platform (1)" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="wearable-1.1.0" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-21.0.0" level="project" />
+    <orderEntry type="library" exported="" name="hellocharts-library-1.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-wearable-7.3.0" level="project" />
+    <orderEntry type="library" exported="" name="recyclerview-v7-21.0.0" level="project" />
+    <orderEntry type="library" exported="" name="play-services-base-7.3.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-22.0.0" level="project" />
     <orderEntry type="library" exported="" name="clockwise-wearable-1.0.2" level="project" />
+    <orderEntry type="library" exported="" name="wearable-1.1.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-22.0.0" level="project" />
-    <orderEntry type="library" exported="" name="hellocharts-library-1.1" level="project" />
-    <orderEntry type="library" exported="" name="play-services-base-7.3.0" level="project" />
   </component>
 </module>

--- a/xDrip-Experimental.iml
+++ b/xDrip-Experimental.iml
@@ -8,7 +8,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/classes/main" />
     <output-test url="file://$MODULE_DIR$/build/classes/test" />
     <exclude-output />


### PR DESCRIPTION
Updated build.gradle to use the latest SDK and libs.
Updated to use gradle 2.1.2.
Updated to use JDK 1_8.

Crashlytics will only report in release mode (only from users not the devs). This is useful so we don't spam the logs if anyone is looking at them.

I had to delete the app and install it again to get this to work correctly. Let me know if you have issues. Users may also have to do a clean install.

@hackingtype1 